### PR TITLE
[FIX] sale_triple_discount: restore original discount field's precision by using change_digit function

### DIFF
--- a/sale_triple_discount/models/sale_order_line.py
+++ b/sale_triple_discount/models/sale_order_line.py
@@ -113,7 +113,6 @@ class SaleOrderLine(models.Model):
         # more digits than allowed from field's precision,
         # so let's increase it just for saving it correctly in cache
         discount_field = self._fields['discount']
-        discount_original_digits = discount_field._digits
         discount_field._digits = (16, 10)
 
         for line in self:
@@ -129,7 +128,7 @@ class SaleOrderLine(models.Model):
             })
 
         # Restore discount field's precision
-        discount_field._digits = discount_original_digits
+        discount_field._digits = dp.get_precision("Discount")(self.env.cr)
         return prev_values
 
     @api.model


### PR DESCRIPTION
Use change_digit function to restore original discount field's precision in order to avoid to have always (16, 10) as precision in case of any errors.